### PR TITLE
provide more information about geo locator results

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -351,7 +351,7 @@ function display_charger_data(local_data) {
                 [charger_latitude, charger_longitude]);
             let distance_string = null;
             const distance_integer = distance.toFixed(0);
-            if ((distance_integer < 2.0) &&ccd (distance_integer > 0)) {
+            if ((distance_integer < 2.0) && (distance_integer > 0)) {
                 distance_string = distance_integer + " mile";
             } else {
                 distance_string = distance_integer + " miles";


### PR DESCRIPTION
I have been looking into the effect we saw last night, of getting results for the previous location.  I could not reproduce the problem, but I added information from the geo locator at the beginning of the results so we can better see what is happening in the future.

Also, I sorted the results with the furthest chargers at the top of the list, since these are the most desirable from the point of view of a long-distance traveler.